### PR TITLE
Fixes DB Config, Tomcat ESUM, PostgreSQL exposure

### DIFF
--- a/aio-base/Dockerfile
+++ b/aio-base/Dockerfile
@@ -16,13 +16,13 @@ ENV CATALINA_BASE /var/lib/tomcat
 
 RUN set -ex \
 	&& export TOMCAT_MAJOR="8" \
-	&& export TOMCAT_VERSION="8.5.51" \
-	&& export TOMCAT_ESUM="bb9207d33d7b4408292186523f3556a3d1454ea172b4a6cde6e0028e2f7a5d9408615cb4ccf8d9fdb75a9f8ce227580f56f929a811eb24ef99e26f980e4bcb48" \
+	&& export TOMCAT_VERSION="8.5.50" \
+	&& export TOMCAT_ESUM="ffca86027d298ba107c7d01c779318c05b61ba48767cc5967ee6ce5a88271bb6ec8eed60708d45453f30eeedddcaedd1a369d6df1b49eea2cd14fa40832cfb90" \
 	&& export TOMCAT_PKG="apache-tomcat-$TOMCAT_VERSION.tar.gz" \
 	&& mkdir -p $CATALINA_HOME \
 	&& mkdir -p $CATALINA_BASE \
 	&& cd $CATALINA_HOME \
-	&& curl -L -O "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/$TOMCAT_PKG" \
+	&& curl -L -O "https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/$TOMCAT_PKG" \
 	&& echo "$TOMCAT_ESUM $TOMCAT_PKG" | sha512sum -c - \
 	&& tar -xvf $TOMCAT_PKG --strip-components=1 \
 	&& rm -f $TOMCAT_PKG \

--- a/aio-base/Dockerfile
+++ b/aio-base/Dockerfile
@@ -16,8 +16,8 @@ ENV CATALINA_BASE /var/lib/tomcat
 
 RUN set -ex \
 	&& export TOMCAT_MAJOR="8" \
-	&& export TOMCAT_VERSION="8.5.38" \
-	&& export TOMCAT_ESUM="3a3e624014faf87091e6dbb8bad13c68240955d62301d22cf3d75a1766859dd97500d6850fbd5d3dc012f08f9301eb24c24fa7175bcca616767fa5c18875072d" \
+	&& export TOMCAT_VERSION="8.5.51" \
+	&& export TOMCAT_ESUM="bb9207d33d7b4408292186523f3556a3d1454ea172b4a6cde6e0028e2f7a5d9408615cb4ccf8d9fdb75a9f8ce227580f56f929a811eb24ef99e26f980e4bcb48" \
 	&& export TOMCAT_PKG="apache-tomcat-$TOMCAT_VERSION.tar.gz" \
 	&& mkdir -p $CATALINA_HOME \
 	&& mkdir -p $CATALINA_BASE \
@@ -137,13 +137,16 @@ ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$CATALINA_HOME/native-j
 ENV POSTGRES_USER axelor
 ENV POSTGRES_PASSWORD axelor
 ENV POSTGRES_DB axelor
+# postgres Server
+ENV DB_SERVER localhost
+ENV DB_SERVER_PORT 5432
 
 ENV PATH $PATH:/usr/lib/postgresql/9.6/bin
 ENV PGDATA /var/lib/postgresql/9.6/main
 
 RUN set -ex \
 	&& echo "host all all all md5" >> /etc/postgresql/9.6/main/pg_hba.conf \
-	&& echo "listen_addresses='localhost'" >> /etc/postgresql/9.6/main/postgresql.conf \
+	&& echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf \
 	&& rm -rf /var/lib/postgresql/9.6/main \
 	&& mkdir -p /var/lib/postgresql/9.6 \
 	&& chown -R postgres:postgres /var/lib/postgresql

--- a/aio-base/docker-compose.yml
+++ b/aio-base/docker-compose.yml
@@ -1,17 +1,27 @@
-version: '3'
+version: '3.7'
+
 services:
   axelor:
+    container_name: app
     image: axelor/aio-base
     build: .
     ports:
       - 80:80
       - 443:443
+      - 5434:5432
     environment:
-      - NGINX_HOST=localhost
-      - NGINX_PORT=443
+      NGINX_HOST: localhost
+      NGINX_PORT: 443
+      POSTGRES_USER: axelor
+      POSTGRES_PASSWORD: axelor
+      POSTGRES_DB: axelor
+      DB_SERVER: localhost
+      DB_SERVER_PORT: 5432
     volumes:
       - ./certs:/etc/nginx/certs:ro
       - ./volumes/var/lib/postgresql:/var/lib/postgresql
       - ./volumes/var/log/postgresql:/var/log/postgresql
       - ./volumes/var/lib/tomcat:/var/lib/tomcat
       - ./volumes/var/log/tomcat:/var/log/tomcat
+      # The following sets the WAR to be deployed avalibale to the container
+      - ${PWD}/axelor-erp-latest.war:/var/lib/tomcat/webapps/ROOT.war

--- a/aio-base/docker-entrypoint.sh
+++ b/aio-base/docker-entrypoint.sh
@@ -92,9 +92,9 @@ prepare_app() {
 			&& cp application.properties app.properties \
 			&& echo >> app.properties \
 			&& echo "application.mode = prod" >> app.properties \
-			&& echo "db.default.url = jdbc:postgresql://localhost:5432/$POSTGRES_DB" >> app.properties \
-			&& echo "db.default.user = axelor" >> app.properties \
-			&& echo "db.default.password = axelor" >> app.properties;
+			&& echo "db.default.url = jdbc:postgresql://$DB_SERVER:$DB_SERVER_PORT/$POSTGRES_DB" >> app.properties \
+			&& echo "db.default.user = $POSTGRES_USER" >> app.properties \
+			&& echo "db.default.password = $POSTGRES_PASSWORD" >> app.properties;
 		exit 0;
 	)
 


### PR DESCRIPTION
-  docker-entrypoint.sh uses environment variables to correct static configuration of database when creating app.properties
- Updates Tomcat ESUM to prevent fail on build
- Exposes PostgreSQL port and allows connections